### PR TITLE
Revert js-yaml upgrade because of breaking changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1783,9 +1783,9 @@
       }
     },
     "@types/js-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.0.tgz",
-      "integrity": "sha512-4vlpCM5KPCL5CfGmTbpjwVKbISRYhduEJvvUWsH5EB7QInhEj94XPZ3ts/9FPiLZFqYO0xoW4ZL8z2AabTGgJA==",
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.5.tgz",
+      "integrity": "sha512-JCcp6J0GV66Y4ZMDAQCXot4xprYB+Zfd3meK9+INSJeVZwJmHAW30BBEEkPzXswMXuiyReUGOP3GxrADc9wPww==",
       "dev": true
     },
     "@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",
-    "@types/js-yaml": "^4.0.0",
+    "@types/js-yaml": "^3.12.5",
     "@types/node": "^14.14.20",
     "@typescript-eslint/parser": "^4.13.0",
     "@vercel/ncc": "^0.27.0",


### PR DESCRIPTION
safeLoad() does require a specified type now and not any. This should be fixed
sometimes. Until then revert the upgrade.